### PR TITLE
Fix: Don't clear non-provided days, deleting now works

### DIFF
--- a/lock_automation/generate_codes_cli.py
+++ b/lock_automation/generate_codes_cli.py
@@ -52,7 +52,7 @@ def main() -> None:
     igloo = IglooClient.from_client_credentials(client_id=args.igloo_client_id, client_secret=args.igloo_client_secret)
     tz = ZoneInfo(args.timezone)
     today = datetime.now(tz).date()
-    updated_codes: dict[str, str] = {}
+    updated_codes: dict[str, str | None] = {}
 
     logger.info(f"Generating new lock pins for the next {args.num_days} days (starting tomorrow):")
     for i in range(1, args.num_days + 1):
@@ -78,6 +78,7 @@ def main() -> None:
 
     logger.info("Updating Playbypoint entry codes...")
     try:
+        updated_codes["12"] = None
         play_by_point.update_entry_codes(owner_id=args.play_by_point_owner, codes=updated_codes)
         logger.info("Successfully updated Playbypoint entry codes")
     except Exception:

--- a/lock_automation/generate_codes_cli.py
+++ b/lock_automation/generate_codes_cli.py
@@ -52,7 +52,7 @@ def main() -> None:
     igloo = IglooClient.from_client_credentials(client_id=args.igloo_client_id, client_secret=args.igloo_client_secret)
     tz = ZoneInfo(args.timezone)
     today = datetime.now(tz).date()
-    updated_codes: dict[str, str | None] = {}
+    updated_codes: dict[str, str] = {}
 
     logger.info(f"Generating new lock pins for the next {args.num_days} days (starting tomorrow):")
     for i in range(1, args.num_days + 1):
@@ -78,7 +78,6 @@ def main() -> None:
 
     logger.info("Updating Playbypoint entry codes...")
     try:
-        updated_codes["12"] = None
         play_by_point.update_entry_codes(owner_id=args.play_by_point_owner, codes=updated_codes)
         logger.info("Successfully updated Playbypoint entry codes")
     except Exception:

--- a/lock_automation/play_by_point.py
+++ b/lock_automation/play_by_point.py
@@ -51,22 +51,28 @@ def _build_update_payload(
 
     for i, (day, variant_id) in enumerate(entry_codes["day_ids"].items()):
         if day in updated_codes:
-            code = updated_codes[day]  # Could be None (explicit clear)
+            # Could be None (explicit clear)
+            # NOTE(thomas): Apparently Rails-style APIs expect "" for clearing string values
+            code = updated_codes[day] or ""
         elif variant_id in entry_codes["existing_values"]:
-            code = entry_codes["existing_values"][variant_id]["value"]  # Preserve existing
+            # Preserve existing code
+            code = entry_codes["existing_values"][variant_id]["value"]
         else:
-            continue  # No update and no existing value
+            # No update and no existing value
+            continue
 
         prefix = f"rule[values_attributes][{i}]"
 
         if variant_id in entry_codes["existing_values"]:
+            # Update if it exists (include the ID)
             existing = entry_codes["existing_values"][variant_id]
             payload[f"{prefix}[id]"] = existing["id"]
             payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
-            payload[f"{prefix}[value]"] = code if code is not None else ""
+            payload[f"{prefix}[value]"] = code
         else:
+            # Create new entry
             payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
-            payload[f"{prefix}[value]"] = code if code is not None else ""
+            payload[f"{prefix}[value]"] = code
 
         payload[f"{prefix}[value_variants_attributes][0][variant_rule_id]"] = entry_codes["variant_id"]
         payload[f"{prefix}[value_variants_attributes][0][rule_variant_item_id]"] = str(variant_id)

--- a/lock_automation/play_by_point.py
+++ b/lock_automation/play_by_point.py
@@ -50,23 +50,23 @@ def _build_update_payload(
     payload: dict[str, Any] = {"rule[id]": entry_codes["rule_id"], "owner": owner_id}
 
     for i, (day, variant_id) in enumerate(entry_codes["day_ids"].items()):
-        # Skip codes that aren't being updated (or set to None)
-        if day not in updated_codes:
-            continue
+        if day in updated_codes:
+            code = updated_codes[day]  # Could be None (explicit clear)
+        elif variant_id in entry_codes["existing_values"]:
+            code = entry_codes["existing_values"][variant_id]["value"]  # Preserve existing
+        else:
+            continue  # No update and no existing value
 
-        code = updated_codes[day]
         prefix = f"rule[values_attributes][{i}]"
 
         if variant_id in entry_codes["existing_values"]:
-            # Update if it exists (include the ID)
             existing = entry_codes["existing_values"][variant_id]
             payload[f"{prefix}[id]"] = existing["id"]
             payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
-            payload[f"{prefix}[value]"] = code
+            payload[f"{prefix}[value]"] = code if code is not None else ""
         else:
-            # Create new entry
             payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
-            payload[f"{prefix}[value]"] = code
+            payload[f"{prefix}[value]"] = code if code is not None else ""
 
         payload[f"{prefix}[value_variants_attributes][0][variant_rule_id]"] = entry_codes["variant_id"]
         payload[f"{prefix}[value_variants_attributes][0][rule_variant_item_id]"] = str(variant_id)

--- a/lock_automation/play_by_point.py
+++ b/lock_automation/play_by_point.py
@@ -51,8 +51,10 @@ def _build_update_payload(
 
     for i, (day, variant_id) in enumerate(entry_codes["day_ids"].items()):
         if day in updated_codes:
-            # Could be None (explicit clear)
             code = updated_codes[day]
+            if code is None:
+                # Omitting from the payload will clear it if it exists, or do nothing if it doesn't
+                continue
         elif variant_id in entry_codes["existing_values"]:
             # Preserve existing code
             code = entry_codes["existing_values"][variant_id]["value"]
@@ -63,21 +65,13 @@ def _build_update_payload(
         prefix = f"rule[values_attributes][{i}]"
 
         if variant_id in entry_codes["existing_values"]:
-            # Update if it exists (include the ID)
-            if code is None:
-                # Omitting the item entirely will clear it
-                continue
+            # We have to include these fields for an update
             existing = entry_codes["existing_values"][variant_id]
             payload[f"{prefix}[id]"] = existing["id"]
-            payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
-            payload[f"{prefix}[value]"] = code
-        else:
-            if code is None:
-                # No existing entry to destroy, and nothing to create
-                continue
-            payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
-            payload[f"{prefix}[value]"] = code
 
+        # We always include these fields for a write
+        payload[f"{prefix}[rule_id]"] = entry_codes["rule_id"]
+        payload[f"{prefix}[value]"] = code
         payload[f"{prefix}[value_variants_attributes][0][variant_rule_id]"] = entry_codes["variant_id"]
         payload[f"{prefix}[value_variants_attributes][0][rule_variant_item_id]"] = str(variant_id)
 


### PR DESCRIPTION
Fixes a bug where the current day's code would get overwritten. More generally, any day in Playbypoint that we aren't generating codes for was getting overwritten. Also fixes deletion so that providing `None` for a day's code will result in that day's code being deleted.

The fix is to merge the existing codes with our updated codes, rather than just providing our updated codes in the PUT request. For deletes, we simply omit from the PUT payload.